### PR TITLE
add runtime blocking pseudocode protocol v0.1

### DIFF
--- a/docs/space-policy-research-location.md
+++ b/docs/space-policy-research-location.md
@@ -1,0 +1,51 @@
+# Space Policy Research Location
+
+**Repository:** `cosmosambassador/AEONIX-CODEX`  
+**Branch:** `protocol/runtime-blocking-v0.1`  
+**Pull Request:** `#2` — `add runtime blocking pseudocode protocol v0.1`  
+**Date noted:** May 26, 2026  
+
+---
+
+## Location Note
+
+The current GitHub location for the Wow Tower 11 / AI Governance in Space Operations public research stack is:
+
+```text
+cosmosambassador/AEONIX-CODEX
+```
+
+This repository is being used as the current public concept home for:
+
+- UNOOSA-style diplomatic policy drafting;
+- treaty-bounded optimization protocol work;
+- lawful action corridor mathematics;
+- runtime blocking pseudocode;
+- auditability and human-authorized AI governance notes for autonomous space operations.
+
+---
+
+## Current File Map
+
+| Layer | File Path | Purpose |
+|---|---|---|
+| Policy / Diplomatic | `whitepaper/unoosa-diplomatic-brief.md` | Public diplomatic framing for human-authorized lawful action corridors. |
+| Technical Protocol | `protocol/treaty-bounded-optimization-pipeline.md` | Runtime architecture connecting optimization, validation, and blocking. |
+| Mathematics | `protocol/corridor-mathematics.md` | Formal boundary proof that operational optimization cannot expand lawful admissibility. |
+| Pseudocode | `protocol/runtime-blocking-pseudocode.md` | Implementation-neutral runtime blocking logic and audit structure. |
+| Repository Lifecycle | `docs/deployment-notes.md` | Housekeeping, sequence, and repository lifecycle notes. |
+| Location Note | `docs/space-policy-research-location.md` | Records where this space policy research stack lives in GitHub. |
+
+---
+
+## Boundary Statement
+
+This repository location is for public-source research, concept drafting, educational framing, protocol development, and repository organization.
+
+It is not a legal instrument, deployed flight system, operational command authority, or official representation of any government, agency, treaty body, or intergovernmental organization.
+
+Core working sentence:
+
+```text
+Autonomous execution is allowed only inside a human-authorized, treaty-bounded lawful action corridor.
+```

--- a/protocol/runtime-blocking-pseudocode.md
+++ b/protocol/runtime-blocking-pseudocode.md
@@ -1,0 +1,195 @@
+# Runtime Blocking Pseudocode
+## Governance-Layer Specification for Lawful Action Corridors
+
+**Project:** Wow Tower 11 / AI Governance in Space Operations / Future Facts SHOW  
+**Document Status:** Working Draft v0.1  
+**Date:** May 26, 2026  
+**Prepared by:** Theresa Janette Morris (TJ) with AI-assisted structural drafting  
+**Classification:** Public Technical Concept / Pseudocode Protocol Draft  
+
+---
+
+## 1. Canonical Position and Scope
+
+This document describes implementation-neutral governance pseudocode for runtime blocking. It does not prescribe physical hardware design, flight-certified actuator logic, secure enclave architecture, non-volatile storage design, or deployed mission-critical behavior.
+
+This blueprint is suitable as a public conceptual protocol draft and repository planning artifact. It is not deployment-ready flight software, not certified safety-critical code, and not an operational command system.
+
+---
+
+## 2. Architectural Core Principles
+
+- **Immutable Snapshot Principle:** Prior to evaluating any state transition or potential policy violation, the system must capture a verifiable, read-only snapshot of the current operating environment. This ensures that the evaluation is based on stable review data that cannot be modified mid-process.
+
+- **Structured Audit Principle:** Every evaluation, decision point, and mitigation trigger must generate a structured log entry containing the rules tested, the inputs provided, the validation outcome, authorization references, validator results, and integrity metadata.
+
+- **Default Non-Execution Principle:** If any validation gate fails, encounters an undefined state, or errors out, the system defaults to a safe, non-execution posture. Execution is permitted only after explicit authorization and successful validation.
+
+---
+
+## 3. Implementation-Neutral Control Flow
+
+```lucid
+// Conceptual Pseudocode: Runtime Validation and Blocking Pipeline
+// Protocol Version: 0.1
+// Intent: Define the formal logic for boundary enforcement and escalation corridors.
+
+function EvaluateStateTransition(proposedTransition, policySet) {
+    // 1. Immutable Snapshot Principle
+    StateSnapshot currentEnvironment := CaptureVerifiableSnapshot();
+
+    // Initialize audit log structure
+    AuditEntry evaluationLog := CreateAuditEntry(proposedTransition);
+
+    try {
+        // 2. Structured Audit Principle - Evaluate Rules
+        for each policy in policySet {
+            ValidationResult result := EvaluatePolicyRule(policy, currentEnvironment, proposedTransition);
+            evaluationLog.AppendValidationResult(result);
+
+            // 3. Default Non-Execution Principle
+            if (result.Status == STATUS_FAIL) {
+                evaluationLog.SetFinalVerdict(VERDICT_BLOCKED);
+                WriteToAuditLog(evaluationLog);
+                TriggerSafeStateMitigation(result.Reason);
+                return EXECUTION_HALTED;
+            }
+        }
+
+        // Final authorization check before permitting execution
+        if (VerifyAuthorization(proposedTransition, evaluationLog)) {
+            evaluationLog.SetFinalVerdict(VERDICT_ALLOWED);
+            WriteToAuditLog(evaluationLog);
+            return EXECUTION_PERMITTED;
+        } else {
+            // Default to safe posture if authorization cannot be verified
+            evaluationLog.SetFinalVerdict(VERDICT_UNAUTHORIZED);
+            WriteToAuditLog(evaluationLog);
+            TriggerSafeStateMitigation("Authorization verification failed.");
+            return EXECUTION_HALTED;
+        }
+
+    } catch (Exception ex) {
+        // Default Non-Execution Principle: fail safe on system error.
+        evaluationLog.SetFinalVerdict(VERDICT_SYSTEM_ERROR);
+        evaluationLog.AddMetadata("Exception", ex.Message);
+        WriteToAuditLog(evaluationLog);
+
+        TriggerSafeStateMitigation("System exception encountered during validation pipeline.");
+        return EXECUTION_HALTED;
+    }
+}
+```
+
+---
+
+## 4. Standard Audit Event Schema
+
+Every evaluation should generate a structured audit event for verification, review, and accountability.
+
+The schema below is illustrative. It is intended to show minimum categories of information that should be captured, not to mandate a specific production database format.
+
+```json
+{
+  "event_id": "uuid-v4-string",
+  "timestamp": "ISO-8601-utc-string",
+  "system_state_snapshot": {
+    "node_id": "string",
+    "telemetry": {},
+    "active_constraints": []
+  },
+  "proposed_action": {
+    "action_id": "string",
+    "payload": {},
+    "requires_sync": true
+  },
+  "decision": "ACTION_EXECUTED | ACTION_BLOCKED: REASON_CODE",
+  "gates": {
+    "authorization": {
+      "result": "pass | fail",
+      "metadata": {}
+    },
+    "treaty": {
+      "result": "pass | fail",
+      "metadata": {}
+    },
+    "safety": {
+      "result": "pass | fail",
+      "metadata": {}
+    },
+    "communications": {
+      "result": "pass | fail",
+      "metadata": {}
+    },
+    "auditability": {
+      "result": "pass | fail",
+      "metadata": {}
+    },
+    "validator": {
+      "result": "pass | fail",
+      "metadata": {}
+    }
+  },
+  "mitigation_strategy": {
+    "strategy_applied": "string",
+    "non_execution_state_selected": true
+  },
+  "emergency_status": false,
+  "review_required": false,
+  "responsible_authority": "",
+  "integrity_hash": "sha256-hex-string"
+}
+```
+
+The audit record should preserve enough information to determine:
+
+- what action was proposed;
+- what system state existed at review time;
+- which gates passed or failed;
+- why execution was allowed or blocked;
+- whether human review is required;
+- how record integrity is preserved.
+
+---
+
+## 5. Mitigation and Escalation Posture
+
+If mitigation handling also fails, the protocol posture remains non-execution and escalation for responsible authority review.
+
+```lucid
+try {
+    return ExecuteMitigationPathway("CRITICAL_RUNTIME_EXCEPTION", evaluationLog);
+} catch (Exception mitigationException) {
+    evaluationLog.AddMetadata("MitigationException", mitigationException.Message);
+    evaluationLog.SetFinalVerdict(VERDICT_BLOCKED);
+
+    try {
+        WriteToAuditLog(evaluationLog);
+    } catch (Exception auditException) {
+        PreserveMinimumFaultRecordIfAvailable(evaluationLog);
+    }
+
+    RequestGovernanceReview(proposedTransition, evaluationLog);
+    return EXECUTION_HALTED;
+}
+```
+
+---
+
+## 6. Operational Governance Bounds
+
+- **Validator Independence:** Final independent validation should rely on a mechanism separate from the local operational optimizer, such as a logically separate validator process, consensus quorum, compliance service, or verification workflow. The purpose is to prevent the local operational optimizer from becoming the sole authority over execution.
+
+- **Telemetry Integrity:** Distributed nodes should preserve telemetry integrity through timestamping, signed or otherwise verifiable state snapshots, replay-resistant audit records, and consistency checks appropriate to the mission design.
+
+- **Default Non-Execution:** If the runtime environment cannot verify authorization, treaty compliance, safety, communications status, auditability, or validator approval, the proposed action should remain blocked.
+
+- **Implementation Neutrality:** This document does not mandate secure enclaves, hardware disconnects, non-volatile storage buffers, actuator logic, or flight-certified deployment patterns.
+
+---
+
+## 7. Boundary Statement
+
+This document is an implementation-neutral pseudocode concept. It is not deployed flight software, legal advice, a government submission, or an operational spacecraft control protocol.
+
+It is intended to support public discussion of lawful action corridors, runtime blocking, auditability, and human-authorized autonomous system governance.


### PR DESCRIPTION
## Summary

- Adds governance-layer runtime blocking specification
- Defines immutable snapshot, structured audit, and default non-execution principles
- Adds implementation-neutral mitigation and escalation pseudocode
- Removes deployment, hardware-control, and flight-software claims

## Visual PR check

- [ ] Title renders correctly
- [ ] No accidental outer code fence wraps the whole file
- [ ] Pseudocode blocks open and close cleanly
- [ ] No hardware disconnect, flight software, or deployment-ready claims remain
- [ ] File path is exactly `protocol/runtime-blocking-pseudocode.md`

## Boundary

This is a public conceptual protocol draft, not deployed flight software, legal advice, a government submission, or an operational spacecraft control protocol.